### PR TITLE
Manually set the eureka.instance.hostname

### DIFF
--- a/adder/src/main/resources/application.properties
+++ b/adder/src/main/resources/application.properties
@@ -3,3 +3,8 @@ server.port=8762
 
 eureka.instance.lease-renewal-interval-in-seconds=5
 eureka.instance.lease-expiration-duration-in-seconds=10
+
+# to ensure nice links in Eureka, let's set the hostname manually
+# otherwise the hostname may be one of following: hostname & domain name / hostname from C:\Windows\System32\drivers\etc\hosts
+common.hostname=localhost
+eureka.instance.hostname=${common.hostname}

--- a/bw-maker/src/main/resources/application.properties
+++ b/bw-maker/src/main/resources/application.properties
@@ -3,3 +3,8 @@ server.port=8763
 
 eureka.instance.lease-renewal-interval-in-seconds=5
 eureka.instance.lease-expiration-duration-in-seconds=10
+
+# to ensure nice links in Eureka, let's set the hostname manually
+# otherwise the hostname may be one of following: hostname & domain name / hostname from C:\Windows\System32\drivers\etc\hosts
+common.hostname=localhost
+eureka.instance.hostname=${common.hostname}

--- a/gateway/src/main/resources/application.properties
+++ b/gateway/src/main/resources/application.properties
@@ -1,2 +1,7 @@
 server.port=8080
 spring.application.name=gateway
+
+# to ensure nice links in Eureka, let's set the hostname manually
+# otherwise the hostname may be one of following: hostname & domain name / hostname from C:\Windows\System32\drivers\etc\hosts
+common.hostname=localhost
+eureka.instance.hostname=${common.hostname}


### PR DESCRIPTION
Manually set the eureka.instance.hostname so there won't be a problem with wrong hostname of the service.

Without setting this, the link in Eureka dashboard will direct to either serviceId or IP found in `C:\Windows\System32\drivers\etc\hosts` (in case of Windows).

From EurekaInstanceConfigBean: The hostname if it can be determined at configuration time (otherwise it will be guessed from OS primitives).